### PR TITLE
docs: settings.jsonによるインストール方法を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,34 +4,12 @@ Claude Code 向けのプラグインマーケットプレイス。
 
 ## インストール
 
-### CLI
-
 ```bash
 # 1. マーケットプレイスを追加
 /plugin marketplace add vanilla-bar/kernel
 
 # 2. プラグインをインストール
 /plugin install ae@kernel
-```
-
-### settings.json
-
-`~/.claude/settings.json`（個人用）または `.claude/settings.json`（プロジェクト用）に追記：
-
-```json
-{
-  "extraKnownMarketplaces": {
-    "kernel": {
-      "source": {
-        "source": "github",
-        "repo": "vanilla-bar/kernel"
-      }
-    }
-  },
-  "enabledPlugins": {
-    "ae@kernel": true
-  }
-}
 ```
 
 ## プラグイン一覧


### PR DESCRIPTION
## Summary
- settings.jsonへの直接記述ではインストールが正しく動作しないため、該当セクションをREADMEから削除
- CLIによるインストール方法のみに統一

## Test plan
- [ ] READMEのインストール手順がCLIのみになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)