### PR TITLE
fix(cut,cut-worktree): 空コミットに--no-verifyを追加

### DIFF
--- a/plugins/ae/skills/cut-worktree/SKILL.md
+++ b/plugins/ae/skills/cut-worktree/SKILL.md
@@ -125,7 +125,7 @@ fi
 
 # 空コミット + push
 cd ../worktrees/{BRANCH_NAME}
-git commit --allow-empty -m "chore: start work on {説明}"
+git commit --allow-empty --no-verify -m "chore: start work on {説明}"
 git push -u origin {BRANCH_NAME}
 
 # ドラフトPR作成

--- a/plugins/ae/skills/cut/SKILL.md
+++ b/plugins/ae/skills/cut/SKILL.md
@@ -79,7 +79,7 @@ DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.na
 ```bash
 git fetch origin
 git checkout -b {BRANCH_NAME} origin/${DEFAULT_BRANCH}
-git commit --allow-empty -m "chore: start work on {説明}"
+git commit --allow-empty --no-verify -m "chore: start work on {説明}"
 git push -u origin {BRANCH_NAME}
 ```
 


### PR DESCRIPTION
## Summary
- cut, cut-worktreeの空コミット（ブランチ起点用）に `--no-verify` を追加
- 空コミットはpre-commitフックの検証対象外のため、フックでブロックされないようにする

Closes #11

## Test plan
- [ ] `/cut` でpre-commitフックに引っかからずブランチが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)